### PR TITLE
fix: English PayPal exports **probably** use US format

### DIFF
--- a/beancount_paypal/lang.py
+++ b/beancount_paypal/lang.py
@@ -53,12 +53,14 @@ class en(base):
         "recipient": "To Email Address",
     }
 
-    _format = "%d/%m/%Y"
+    _format = "%m/%d/%Y"  # US date format: MM/DD/YYYY
     _from_checking = "Bank Deposit to PP Account "
     _currency_conversion = "General Currency Conversion"
 
     def decimal(self, data):
-        return data.replace(".", "").replace(",", ".")
+        # US format: period is decimal separator, comma is thousands separator
+        # Remove thousands separators (commas) and keep period as decimal
+        return data.replace(",", "")
 
 
 class de(base):


### PR DESCRIPTION
This is only an assumption because I don't have English export files.